### PR TITLE
fix:tensorflow inference fix

### DIFF
--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -456,7 +456,7 @@ where
                     shape.size,
                     halide_type_of::<T::H>(),
                     core::ptr::null_mut(),
-                    DimensionType::Caffe.to_mnn_sys(),
+                    dm_type.to_mnn_sys(),
                 )
             }
         };


### PR DESCRIPTION
#13 This PR fixes an issue where TensorFlow-converted models produced incorrect outputs due to mismatched dimension type handling. The core problem was that DimensionType::Caffe was being incorrectly applied even for TensorFlow-style models.